### PR TITLE
Deploy production system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,5 +47,6 @@ python-decouple>=3.6
 whitenoise>=6.4.0
 
 # Monitoring
-sentry-sdk>=1.15.0# Exclude django-csp to prevent CSP conflicts
+# Exclude django-csp to prevent CSP conflicts
+sentry-sdk>=1.15.0
 django-csp==0.0.0


### PR DESCRIPTION
Fix invalid pip requirement syntax in `requirements.txt` to enable successful Docker builds.

The `sentry-sdk` line previously contained a comment on the same line, which caused an `ERROR: Invalid requirement` during `pip install` within the Docker build process. Moving the comment to a separate line resolves this syntax issue.

---

[Open in Web](https://cursor.com/agents?id=bc-059b5d3f-9a02-490e-90d4-bd00b2aa67c1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-059b5d3f-9a02-490e-90d4-bd00b2aa67c1) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)